### PR TITLE
add `alfred-unlink` script - fixes #10

### DIFF
--- a/lib/unlink.js
+++ b/lib/unlink.js
@@ -1,0 +1,5 @@
+'use strict';
+const path = require('path');
+const del = require('del');
+
+module.exports = (workflowDir, pkg) => del(path.join(workflowDir, pkg.name), {force: true});

--- a/link.js
+++ b/link.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-const alfyLink = require('./');
+const alfredLink = require('./');
 
 const npmGlobal = process.env.npm_config_global;
 
@@ -10,7 +10,7 @@ if (npmGlobal === '') {
 }
 
 // Only transform if `alfred-link` is called from `npm -g`
-alfyLink({transform: npmGlobal}).catch(err => {
+alfredLink.link({transform: npmGlobal}).catch(err => {
 	console.error(err);
 	process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
       "url": "sindresorhus.com"
     }
   ],
-  "bin": "cli.js",
+  "bin": {
+    "alfred-link": "link.js",
+    "alfred-unlink": "unlink.js"
+  },
   "engines": {
     "node": ">=4"
   },
@@ -25,8 +28,9 @@
   },
   "files": [
     "index.js",
-    "lib",
-    "cli.js"
+    "link.js",
+    "unlink.js",
+    "lib"
   ],
   "keywords": [
     "cli-app",

--- a/readme.md
+++ b/readme.md
@@ -12,13 +12,14 @@ $ npm install --save alfred-link
 
 ## Usage
 
-Add the `alfred-link` command as `postinstall` script of your Alfred package.
+Add the `alfred-link` command as `postinstall` script of your Alfred package and add `alfred-unlink` as `preuninstall` script to clean up the resources when the workflow gets uninstalled.
 
 ```json
 {
   "name": "alfred-unicorn",
   "scripts": {
-    "postinstall": "alfred-link"
+    "postinstall": "alfred-link",
+    "preuninstall": "alfred-unlink"
   }
 }
 ```
@@ -50,6 +51,12 @@ When developing an Alfred workflow, you can call `alfred-link` directly from you
 
 ```
 $ ./node_modules/.bin/alfred-link
+```
+
+To remove the symlink afterwards, you can call `alfred-unlink`.
+
+```
+$ ./node_modules/.bin/alfred-unlink
 ```
 
 

--- a/unlink.js
+++ b/unlink.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+'use strict';
+const alfredLink = require('./');
+
+alfredLink.unlink().catch(err => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
This will solve #10 as it adds the possibility to add `alfred-unlink` to the `preuninstall` hook. Currently, symlinks aren't being cleaned up after uninstallation.

@sindresorhus What do you think about this approach? Or should we create a separate `alfred-unlink` package instead as `alfy` will abstract the underlying packages away. I would suggest that `alfy` exposes a `alfy-cleanup` script or something like that.

I also think we should remove stored `config` files and cache files from the system.