### PR TITLE
docs(dev): encourage leveraging npm scripts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,16 +47,16 @@ This package will update the `info.plist` file when the workflow is being instal
 
 ## Development
 
-When developing an Alfred workflow, you can call `alfred-link` directly from your cli. Either by installing `alfred-link` globally or by calling `alfred-link` from your `node_modules/.bin` directory. This will create a symlink in the Alfred workflows directory pointing to your development location without transforming `info.plist`.
+When developing an Alfred workflow, you can call `alfred-link` directly from your cli. Either by installing `alfred-link` globally or by using the [postinstall script](#Usage) to implicitly call the local installation. This will create a symlink in the Alfred workflows directory pointing to your development location without transforming `info.plist`.
 
 ```
-$ ./node_modules/.bin/alfred-link
+$ npm run postinstall # or `alfred-link` if global
 ```
 
 To remove the symlink afterwards, you can call `alfred-unlink`.
 
 ```
-$ ./node_modules/.bin/alfred-unlink
+$ npm run preuninstall # or `alfred-unlink` if global
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -47,16 +47,18 @@ This package will update the `info.plist` file when the workflow is being instal
 
 ## Development
 
-When developing an Alfred workflow, you can call `alfred-link` directly from your cli. Either by installing `alfred-link` globally or by using `npx` to call the local installation. This will create a symlink in the Alfred workflows directory pointing to your development location without transforming `info.plist`.
+When developing an Alfred workflow, you can call `alfred-link` directly from your cli. Use `npx` to call the local installation of `alfred-link` and `alfred-unlink`.
 
 ```
-$ npx alfred-link  # or just `alfred-link` if global
+$ npx alfred-link
 ```
+
+This will create a symlink in the Alfred workflows directory pointing to your development location without transforming `info.plist`.
 
 To remove the symlink afterwards, you can call `alfred-unlink`.
 
 ```
-$ npx alfred-unlink  # or just `alfred-unlink` if global
+$ npx alfred-unlink
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ This package will update the `info.plist` file when the workflow is being instal
 
 ## Development
 
-When developing an Alfred workflow, you can call `alfred-link` directly from your cli. Either by installing `alfred-link` globally or by using the [postinstall script](#Usage) to implicitly call the local installation. This will create a symlink in the Alfred workflows directory pointing to your development location without transforming `info.plist`.
+When developing an Alfred workflow, you can call `alfred-link` directly from your cli. Either by installing `alfred-link` globally or by using the [postinstall script](#usage) to implicitly call the local installation. This will create a symlink in the Alfred workflows directory pointing to your development location without transforming `info.plist`.
 
 ```
 $ npm run postinstall # or `alfred-link` if global

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Add the `alfred-link` command as `postinstall` script of your Alfred package and
 ```json
 {
   "name": "alfred-unicorn",
-  "scripts": {
+  "scripts": { 
     "postinstall": "alfred-link",
     "preuninstall": "alfred-unlink"
   }
@@ -47,16 +47,16 @@ This package will update the `info.plist` file when the workflow is being instal
 
 ## Development
 
-When developing an Alfred workflow, you can call `alfred-link` directly from your cli. Either by installing `alfred-link` globally or by using the [postinstall script](#usage) to implicitly call the local installation. This will create a symlink in the Alfred workflows directory pointing to your development location without transforming `info.plist`.
+When developing an Alfred workflow, you can call `alfred-link` directly from your cli. Either by installing `alfred-link` globally or by using `npx` to call the local installation. This will create a symlink in the Alfred workflows directory pointing to your development location without transforming `info.plist`.
 
 ```
-$ npm run postinstall # or `alfred-link` if global
+$ npx alfred-link  # or just `alfred-link` if global
 ```
 
 To remove the symlink afterwards, you can call `alfred-unlink`.
 
 ```
-$ npm run preuninstall # or `alfred-unlink` if global
+$ npx alfred-unlink  # or just `alfred-unlink` if global
 ```
 
 


### PR DESCRIPTION
In the spirit of having "one right way" of doing things in software, I'm proposing re-using the npm scripts later in the documentation. I feel it makes more sense amnyway in that they'll be running the bins the way they'll actually be run in the wild.