### PR TITLE
Create workflow directory if necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
 	},
 	"devDependencies": {
 		"xo": "^0.23.0"
-  }
+	}
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "dependencies": {
     "del": "^2.2.2",
+    "make-dir": "^1.3.0",
     "path-exists": "^3.0.0",
     "pify": "^2.3.0",
     "plist": "^2.0.1",


### PR DESCRIPTION
If you’ve never used Alfred workflows before, there’s no `workflows` directory in `Alfred.alfredpreferences`. Therefore, as a new user, running `npm install -g alfred-aws`, for example, will error stating that the workflow directory does not exist.

In this pull request, I’ve changed the behavior so that the workflow directory is automatically created (but only as long as `Alfred.alfredpreferences` already exists).

Fixes #21